### PR TITLE
Fix bug in table_schema primary key flag

### DIFF
--- a/lib/rdbi/driver/postgresql.rb
+++ b/lib/rdbi/driver/postgresql.rb
@@ -91,6 +91,7 @@ class RDBI::Driver::PostgreSQL < RDBI::Driver
           FROM information_schema.columns c
             LEFT JOIN information_schema.key_column_usage kcu
               ON kcu.column_name = c.column_name
+              AND kcu.table_name = c.table_name
               LEFT JOIN information_schema.table_constraints tc
                 ON tc.constraint_name = kcu.constraint_name
           WHERE c.table_schema = ? and c.table_name = ?


### PR DESCRIPTION
The primary key flag was incorrectly activating if a column by the same name in a different table was setup as a primary key.

For example:
## Person Table

person_id (primary key)
company_id (not primary key)
## Company Table

company_id (primary key)

In person.company_id tc.constraint_type == "PRIMARY KEY" returned true. Adding an additional join on table_name removed the error.
